### PR TITLE
octagon-hisi.inc: Fix image build

### DIFF
--- a/conf/machine/include/octagon-hisi.inc
+++ b/conf/machine/include/octagon-hisi.inc
@@ -103,7 +103,7 @@ IMAGE_CMD_octagonemmc_append = "\
     mkdir -p ${DEPLOY_DIR_IMAGE}/userdata/linuxrootfs2; \
     mkdir -p ${DEPLOY_DIR_IMAGE}/userdata/linuxrootfs3; \
     mkdir -p ${DEPLOY_DIR_IMAGE}/userdata/linuxrootfs4; \
-    cp -a ${IMAGE_ROOTFS}/* ${DEPLOY_DIR_IMAGE}/userdata/linuxrootfs1/; \
+    cp -fR ${IMAGE_ROOTFS}/* ${DEPLOY_DIR_IMAGE}/userdata/linuxrootfs1/; \
     dd if=/dev/zero of=${DEPLOY_DIR_IMAGE}/${MACHINE}-partitions/rootfs.ext4 seek=${IMAGE_ROOTFS_SIZE} count=60 bs=1024; \
     mkfs.ext4 -F -i 4096 ${DEPLOY_DIR_IMAGE}/${MACHINE}-partitions/rootfs.ext4 -d ${DEPLOY_DIR_IMAGE}/userdata; \
     cd ${IMAGE_ROOTFS}; \


### PR DESCRIPTION
cp: failed to preserve ownership for /home/hains/openpli-oe-core/build/tmp/deploy/images/sf8008/userdata/linuxrootfs1/var/scce: Operation not permitted
| cp: failed to preserve ownership for '/home/hains/openpli-oe-core/build/tmp/deploy/images/sf8008/userdata/linuxrootfs1/var/openldap/data': Operation not permitted
| cp: failed to preserve ownership for '/home/hains/openpli-oe-core/build/tmp/deploy/images/sf8008/userdata/linuxrootfs1/var/openldap': Operation not permitted
| cp: failed to preserve ownership for '/home/hains/openpli-oe-core/build/tmp/deploy/images/sf8008/userdata/linuxrootfs1/var': Operation not permitted
| WARNING: exit code 1 from a shell command.
| ERROR: ExecutionError('/home/hains/openpli-oe-core/build/tmp/work/sf8008-oe-linux-gnueabi/openpli-enigma2-image/1.0-r0/temp/run.do_image_octagonemmc.117223', 1, None, None)